### PR TITLE
fix: center layout, text overflow and spacing

### DIFF
--- a/src/components/TopicPage.tsx
+++ b/src/components/TopicPage.tsx
@@ -33,10 +33,10 @@ export const TopicPage = (props: TopicPageProps) => {
           content={props.headDescription}
         />
       </Head>
-      <main>
-        <div className="grid grid-cols-12  flex-col items-center justify-center gap-12 border-b px-4">
+      <main className="bg-gray-50">
+        <div className="bg-white grid grid-cols-12 flex-col items-center justify-center gap-12 border-b px-4">
           <div className="col-span-3" />
-          <div className="container relative col-span-6 flex  py-5 sm:py-12">
+          <div className="container relative col-span-6 flex py-5 sm:py-12">
             <div className="mb-3 mt-0 sm:mb-4 sm:mt-4">
               <h3 className="flex text-3xl font-bold tracking-tight text-slate-900">
                 {props.title}
@@ -48,7 +48,7 @@ export const TopicPage = (props: TopicPageProps) => {
             </div>
           </div>
         </div>
-        <div className="grid h-screen sm:grid-cols-3 md:grid-cols-6  content-start gap-4 bg-gray-50 px-5 pt-4 sm:pt-12">
+        <div className="container mx-auto w-fit grid h-screen sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-6 content-start gap-4 px-5 pt-4 sm:pt-12">
           <Topics
             isOpen={isOpen}
             toggle={toggle}

--- a/src/components/Topics.tsx
+++ b/src/components/Topics.tsx
@@ -48,7 +48,7 @@ const Modal = (props: modalProps) => {
     >
       <div
         onClick={(e) => e.stopPropagation()}
-        className=" block h-full md:w-1/2 bg-slate-50 p-4 overflow-y-auto"
+        className="block h-full w-fit bg-slate-50 p-4 lg:p-8 xl:px-12 overflow-y-auto"
       >
         <button
           type="button"
@@ -91,13 +91,13 @@ const Topic = (props: topicProps) => {
   const status: Status = data?.status || Status.PENDING;
 
   return (
-    <div className="h-20 w-full ">
+    <div className="flex h-full justify-items-stretch">
       <button
-        className={`flex h-20 w-full max-w-xs flex-col justify-center rounded-xl py-7 text-black ${topicColorClasses[status]}`}
+        className={`w-full rounded-xl px-3 py-6 md:py-8 md:px-4 text-black ${topicColorClasses[status]}`}
         type="button"
         onClick={toggle}
       >
-        <h5 className="self-center text-xl font-bold">{topic.title}</h5>
+        <h5 className="self-center -tracking-[0.01em] text-base xl:text-lg font-bold">{topic.title}</h5>
       </button>
       <Modal
         isOpen={isOpen}
@@ -105,7 +105,7 @@ const Topic = (props: topicProps) => {
         topicId={topic.id}
         progress={status}
       >
-        <div className="mkdown mt-3">
+        <div className="mkdown mt-3 max-w-prose">
           <ReactMarkdown linkTarget="_blank">{topic.body}</ReactMarkdown>
         </div>
       </Modal>


### PR DESCRIPTION
before -> after
![image](https://github.com/gutogalego/roadmap-investidor/assets/61759797/934a0550-9954-4ef8-89b2-e8725389b571)
![image](https://github.com/gutogalego/roadmap-investidor/assets/61759797/c055ca28-ca48-44cc-bab3-ea4fe7bc978c)
![image](https://github.com/gutogalego/roadmap-investidor/assets/61759797/0d4e7d37-ddf8-4aa8-9e57-4a77b7280b0a)


